### PR TITLE
Run go mod tidy, fix build with gccgo 12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/radovskyb/watcher v1.0.2
 	golang.org/x/net v0.0.0-20180502164142-640f4622ab69
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e // indirect
-	golang.org/x/text v0.3.0
-	google.golang.org/genproto v0.0.0-20180427144745-86e600f69ee4
+	golang.org/x/text v0.3.0 // indirect
+	google.golang.org/genproto v0.0.0-20180427144745-86e600f69ee4 // indirect
 	google.golang.org/grpc v1.11.3
 )

--- a/go.sum
+++ b/go.sum
@@ -2,11 +2,12 @@ github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekf
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/protobuf v1.1.0 h1:0iH4Ffd/meGoXqF2lSAhZHt8X+cPgkfn/cb6Cce5Vpc=
 github.com/golang/protobuf v1.1.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/google/subcommands v0.0.0-20180305171600-a3682377147e h1:7OHlrhMiU9KC4cXeWfmYFHLACBw7a6sJ5rWdAICpn1g=
 github.com/google/subcommands v0.0.0-20180305171600-a3682377147e/go.mod h1:ZjhPrFU+Olkh9WazFPsl27BQ4UPiG37m3yTrtFlrHVk=
+github.com/hashicorp/go-version v0.0.0-20180322230233-23480c066577 h1:at4+18LrM8myamuV7/vT6x2s1JNXp2k4PsSbt4I02X4=
 github.com/hashicorp/go-version v0.0.0-20180322230233-23480c066577/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/radovskyb/watcher v1.0.2 h1:9L5TsZUbo1nKhQEQPtICVc+x9UZQ6VPdBepLHyGw/bQ=
 github.com/radovskyb/watcher v1.0.2/go.mod h1:78okwvY5wPdzcb1UYnip1pvrZNIVEIh/Cm+ZuvsUYIg=
-github.com/the-maldridge/popcorn v0.2.1 h1:SOK+U41EQJ4J8ojuT5nFWly0MaIlAqvYwoZxSRYYnRk=
-github.com/the-maldridge/popcorn v0.2.1/go.mod h1:jsMhyCKsEHgmG5BBbNOrp1jETcX6rUuouQMcjKtlKRw=
 golang.org/x/net v0.0.0-20180502164142-640f4622ab69 h1:+Ybm3UzSfPpp+Hlr62ZTCtbC9DmCKX61f0r74+peGts=
 golang.org/x/net v0.0.0-20180502164142-640f4622ab69/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=


### PR DESCRIPTION
Fixes multiple "missing go.sum entry for module providing package" errors with gccgo 12.